### PR TITLE
Monterey and managed_python

### DIFF
--- a/LDAPv3Write - Monterey.py
+++ b/LDAPv3Write - Monterey.py
@@ -1,0 +1,20 @@
+#/Library/ManagedFrameworks/Python/Python3.framework/Versions/Current/bin/python3
+
+from OpenDirectory import ODSession, ODNode, kODNodeTypeConfigure
+from Foundation import NSData, NSMutableData
+import sys
+
+# Reading the LDAP plist
+LDAPCONFIGFILE = open(sys.argv[1], "r")
+LDAPCONFIGSTR = LDAPCONFIGFILE.read()
+LDAPCONFIGFILE.close()
+LDAPCONFIG = LDAPCONFIGSTR.encode('utf-8')
+
+# Write the plist
+session = ODSession.defaultSession()
+odconfnode, err = ODNode.nodeWithSession_type_error_(session, kODNodeTypeConfigure, None)
+config_data = NSData.dataWithBytes_length_(LDAPCONFIG, len(LDAPCONFIG))
+root_auth = b'\x00'*32
+request = NSMutableData.dataWithBytes_length_(root_auth, 32)
+request.appendData_(config_data)
+response, err = odconfnode.customCall_sendData_error_(99991, request, None)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Writing binding information programmatically on macOS Catalina and above
 ## The Problem
 In macOS Catalina and Big Sur the `/Library/Preferences/OpenDirectory/Configurations` folder appears to be protected by SIP or some other unknown protection mechanism. This leaves the common Open Directory binding installation of placing down the configuration plist files nonfunctional. This can be a hard stop when it comes to fully programmatically provisioning a machine via DEP, with the only workaround before discovering this method being using the Directory Utility GUI to manually enter the binding settings.
 
+To further complicate things, Apple removed Python 2.7 starting with Monterey 12.3 (in fairness, after years of warning us they would do so). The folks at macadmins.org have packaged a purpose-built, self-contained python3 package for exactly this type of administrative need. Therefore, the Monterey version of this script has been modified to use python3 and requires that the python_recommended.pkg from macadmins be installed. Latest versions of this package, signed and unsigned, can be found here: https://github.com/macadmins/python/releases  
+
 ## The Components of an OD Bind
 In a typical Open Directory bind there are three main plist files contained within the Configurations directory, they are as follows:
 


### PR DESCRIPTION
Added a Monterey compatible version of the script that uses the macadmins.org managed_python package to replace the bundled Python that Apple removed starting in macOS 12.3; the Monterey version converts the LDAP config info from a string into bytes as required by the python3 environment in managed_python, and the README now includes a link to the releases page of that repository.